### PR TITLE
Activity Reordering and Edit Mode Enhancements

### DIFF
--- a/ActivityTracker/app/Activities.tsx
+++ b/ActivityTracker/app/Activities.tsx
@@ -53,7 +53,7 @@ const FloatingIconComponent = ({ icon, onAnimationComplete, startX, startY }) =>
 
 const ActivitiesScreen: React.FC = () => {
   const router = useRouter();
-  const { activities, activityDetails, loading, deleteActivity, addActivityEntry, refreshData } = useActivityData();
+  const { activities, activityDetails, loading, deleteActivity, addActivityEntry, refreshData, reorderActivities } = useActivityData();
   const [searchQuery, setSearchQuery] = useState('');
   const [isEditMode, setIsEditMode] = useState(false);
   const rotation = useSharedValue(0);
@@ -96,8 +96,44 @@ const ActivitiesScreen: React.FC = () => {
 
 
   const toggleEditMode = () => {
+    if (activities.length === 0) return;
     setIsEditMode(!isEditMode);
     rotation.value = withTiming(isEditMode ? 0 : 360, { duration: 300 });
+  };
+
+  React.useEffect(() => {
+    if (activities.length === 0 && isEditMode) {
+      setIsEditMode(false);
+      rotation.value = withTiming(0, { duration: 300 });
+    }
+  }, [activities.length, isEditMode]);
+
+  const handleMoveUp = (filteredIndex: number) => {
+    if (filteredIndex === 0) return;
+    const activityToMove = filteredActivities[filteredIndex];
+    const targetActivity = filteredActivities[filteredIndex - 1];
+
+    const newActivities = activities.map(a => {
+        if (a.id === activityToMove.id) return { ...a, orderIndex: targetActivity.orderIndex };
+        if (a.id === targetActivity.id) return { ...a, orderIndex: activityToMove.orderIndex };
+        return a;
+    }).sort((a, b) => (a.orderIndex ?? 0) - (b.orderIndex ?? 0));
+
+    reorderActivities(newActivities);
+  };
+
+  const handleMoveDown = (filteredIndex: number) => {
+    if (filteredIndex === filteredActivities.length - 1) return;
+    const activityToMove = filteredActivities[filteredIndex];
+    const targetActivity = filteredActivities[filteredIndex + 1];
+
+    const newActivities = activities.map(a => {
+        if (a.id === activityToMove.id) return { ...a, orderIndex: targetActivity.orderIndex };
+        if (a.id === targetActivity.id) return { ...a, orderIndex: activityToMove.orderIndex };
+        return a;
+    }).sort((a, b) => (a.orderIndex ?? 0) - (b.orderIndex ?? 0));
+
+    reorderActivities(newActivities);
   };
 
   return (
@@ -108,9 +144,17 @@ const ActivitiesScreen: React.FC = () => {
           <TouchableOpacity onPress={() => router.push('/SearchByTag')} style={{ marginRight: 15 }}>
             <Icon name="tag-search-outline" size={30} color={theme.colors.text} />
           </TouchableOpacity>
-          <TouchableOpacity onPress={toggleEditMode} style={{ marginRight: 15 }}>
-            <Animated.View style={animatedStyle}>
-              <Icon name={isEditMode ? "check" : "pencil-outline"} size={30} color={theme.colors.text} />
+          <TouchableOpacity
+            onPress={toggleEditMode}
+            style={{ marginRight: 15 }}
+            disabled={activities.length === 0}
+          >
+            <Animated.View style={[animatedStyle, activities.length === 0 && { opacity: 0.5 }]}>
+              <Icon
+                name={isEditMode ? "check" : "pencil-outline"}
+                size={30}
+                color={activities.length === 0 ? theme.colors.disabled : theme.colors.text}
+              />
             </Animated.View>
           </TouchableOpacity>
           <TouchableOpacity onPress={() => router.push('/Settings')}>
@@ -143,6 +187,10 @@ const ActivitiesScreen: React.FC = () => {
               onDelete={() => handleDelete(item.id)}
               onAddTime={(x, y) => handleAddTime(item.id, item.icon, x, y)}
               lastEntryDate={lastEntryDate}
+              onMoveUp={() => handleMoveUp(index)}
+              onMoveDown={() => handleMoveDown(index)}
+              isFirst={index === 0}
+              isLast={index === filteredActivities.length - 1}
             />
           );
         }}

--- a/ActivityTracker/src/components/ActivityListItem.tsx
+++ b/ActivityTracker/src/components/ActivityListItem.tsx
@@ -12,9 +12,24 @@ interface ActivityListItemProps {
   onDelete: () => void;
   onAddTime: (x: number, y: number) => void;
   lastEntryDate: Date | null;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  isFirst?: boolean;
+  isLast?: boolean;
 }
 
-const ActivityListItem: React.FC<ActivityListItemProps> = ({ item, onPress, isEditMode, onDelete, onAddTime, lastEntryDate }) => {
+const ActivityListItem: React.FC<ActivityListItemProps> = ({
+    item,
+    onPress,
+    isEditMode,
+    onDelete,
+    onAddTime,
+    lastEntryDate,
+    onMoveUp,
+    onMoveDown,
+    isFirst,
+    isLast
+}) => {
   const [timeAgo, setTimeAgo] = useState(lastEntryDate ? formatTimeAgo(lastEntryDate) : 'Never');
   const addButtonRef = React.useRef<TouchableOpacity>(null);
 
@@ -43,9 +58,25 @@ const ActivityListItem: React.FC<ActivityListItemProps> = ({ item, onPress, isEd
         <Text style={styles.lastDone}>{timeAgo}</Text>
       </View>
       {isEditMode ? (
-        <TouchableOpacity onPress={onDelete} style={styles.deleteButton}>
-          <Icon name="trash-can-outline" size={24} color={theme.colors.text} />
-        </TouchableOpacity>
+        <View style={styles.editControls}>
+          <TouchableOpacity
+            onPress={onMoveUp}
+            disabled={isFirst}
+            style={[styles.moveButton, isFirst && styles.disabledButton]}
+          >
+            <Icon name="arrow-up" size={28} color={isFirst ? theme.colors.disabled : theme.colors.text} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={onMoveDown}
+            disabled={isLast}
+            style={[styles.moveButton, isLast && styles.disabledButton, { marginRight: 10 }]}
+          >
+            <Icon name="arrow-down" size={28} color={isLast ? theme.colors.disabled : theme.colors.text} />
+          </TouchableOpacity>
+          <TouchableOpacity onPress={onDelete} style={styles.deleteButton}>
+            <Icon name="trash-can-outline" size={24} color={theme.colors.text} />
+          </TouchableOpacity>
+        </View>
       ) : (
         <TouchableOpacity ref={addButtonRef} onPress={handleAddTime} style={styles.addButton}>
           <Icon name="plus" size={32} color={theme.colors.primary} />
@@ -85,6 +116,16 @@ const styles = StyleSheet.create({
     color: theme.colors.subtext,
     fontSize: 14,
     marginTop: 5,
+  },
+  editControls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  moveButton: {
+    padding: 5,
+  },
+  disabledButton: {
+    opacity: 0.5,
   },
   deleteButton: {
     backgroundColor: theme.colors.notification,

--- a/ActivityTracker/src/data/activities.ts
+++ b/ActivityTracker/src/data/activities.ts
@@ -3,6 +3,7 @@ export interface Activity {
   name: string;
   lastDone: string;
   icon: string;
+  orderIndex: number;
 }
 
 export const activities: Activity[] = [];

--- a/ActivityTracker/src/hooks/useActivityData.ts
+++ b/ActivityTracker/src/hooks/useActivityData.ts
@@ -43,10 +43,12 @@ export const useActivityData = () => {
       throw new Error('An activity with this name already exists.');
     }
 
+    const maxOrderIndex = activities.reduce((max, a) => Math.max(max, a.orderIndex ?? 0), -1);
     const activityToAdd: Activity = {
       ...newActivity,
       id: newId,
       lastDone: 'Never',
+      orderIndex: maxOrderIndex + 1,
     };
 
     await database.addActivity(activityToAdd);
@@ -58,7 +60,18 @@ export const useActivityData = () => {
 
   const updateActivity = async (updatedActivity: Activity) => {
     await database.updateActivity(updatedActivity);
-    setActivities(prev => prev.map(a => a.id === updatedActivity.id ? updatedActivity : a));
+    setActivities(prev =>
+        prev.map(a => a.id === updatedActivity.id ? updatedActivity : a)
+            .sort((a, b) => (a.orderIndex ?? 0) - (b.orderIndex ?? 0))
+    );
+  };
+
+  const reorderActivities = async (newActivities: Activity[]) => {
+    // Update state immediately for responsiveness
+    setActivities(newActivities);
+
+    // Persist changes to database
+    await database.updateActivitiesOrder(newActivities);
   };
 
   const addActivityEntry = async (activityId: string, startDate: Date, endDate: Date, notes?: string, image?: string, entryTags?: Tag[]) => {
@@ -173,6 +186,7 @@ export const useActivityData = () => {
     addTag,
     updateTag,
     deleteTag,
+    reorderActivities,
     refreshData: loadData,
   };
 };

--- a/ActivityTracker/src/utils/database.ts
+++ b/ActivityTracker/src/utils/database.ts
@@ -27,7 +27,8 @@ export const getDb = async () => {
             id TEXT PRIMARY KEY NOT NULL,
             name TEXT NOT NULL,
             lastDone TEXT,
-            icon TEXT
+            icon TEXT,
+            orderIndex INTEGER DEFAULT 0
         );
         CREATE TABLE IF NOT EXISTS entries (
             id TEXT PRIMARY KEY NOT NULL,
@@ -84,6 +85,17 @@ const migrateDatabase = async (db: SQLite.SQLiteDatabase) => {
       // but we can leave 'date' as it's now redundant.
     }
 
+    const activitiesTableInfo = await db.getAllAsync<any>("PRAGMA table_info(activities)");
+    const hasOrderIndex = activitiesTableInfo.some(col => col.name === 'orderIndex');
+    if (!hasOrderIndex) {
+      console.log('Migrating activities table: adding orderIndex...');
+      await db.execAsync('ALTER TABLE activities ADD COLUMN orderIndex INTEGER DEFAULT 0');
+      const rows = await db.getAllAsync<any>("SELECT id FROM activities");
+      for (let i = 0; i < rows.length; i++) {
+        await db.runAsync('UPDATE activities SET orderIndex = ? WHERE id = ?', [i, rows[i].id]);
+      }
+    }
+
     const tables = await db.getAllAsync<any>("SELECT name FROM sqlite_master WHERE type='table'");
     const hasTags = tables.some(t => t.name === 'tags');
     if (!hasTags) {
@@ -112,10 +124,11 @@ const seedInitialData = async (db: SQLite.SQLiteDatabase) => {
     const activitiesCount = await db.getFirstAsync<{count: number}>('SELECT COUNT(*) as count FROM activities');
     if (activitiesCount?.count === 0) {
         console.log('Seeding initial data...');
-        for (const activity of initialActivities) {
+        for (let i = 0; i < initialActivities.length; i++) {
+            const activity = initialActivities[i];
             await db.runAsync(
-                'INSERT INTO activities (id, name, lastDone, icon) VALUES (?, ?, ?, ?)',
-                [activity.id, activity.name, activity.lastDone, activity.icon]
+                'INSERT INTO activities (id, name, lastDone, icon, orderIndex) VALUES (?, ?, ?, ?, ?)',
+                [activity.id, activity.name, activity.lastDone, activity.icon, i]
             );
             const entries = initialActivityDetails[activity.id] || [];
             for (const entry of entries) {
@@ -139,10 +152,11 @@ const migrateFromAsyncStorage = async (db: SQLite.SQLiteDatabase) => {
         ? JSON.parse(storedActivityDetails)
         : {};
 
-      for (const activity of activities) {
+      for (let i = 0; i < activities.length; i++) {
+        const activity = activities[i];
         await db.runAsync(
-          'INSERT OR REPLACE INTO activities (id, name, lastDone, icon) VALUES (?, ?, ?, ?)',
-          [activity.id, activity.name, activity.lastDone, activity.icon]
+          'INSERT OR REPLACE INTO activities (id, name, lastDone, icon, orderIndex) VALUES (?, ?, ?, ?, ?)',
+          [activity.id, activity.name, activity.lastDone, activity.icon, i]
         );
 
         const entries = activityDetails[activity.id] || [];
@@ -168,15 +182,15 @@ const migrateFromAsyncStorage = async (db: SQLite.SQLiteDatabase) => {
 export const getActivities = async (): Promise<Activity[]> => {
   const db = await getDb();
   if (!db) return []; // Should not happen with Metro resolving to .web.ts
-  return await db.getAllAsync<Activity>('SELECT * FROM activities');
+  return await db.getAllAsync<Activity>('SELECT * FROM activities ORDER BY orderIndex ASC');
 };
 
 export const addActivity = async (activity: Activity) => {
   const db = await getDb();
   if (!db) return;
   await db.runAsync(
-    'INSERT INTO activities (id, name, lastDone, icon) VALUES (?, ?, ?, ?)',
-    [activity.id, activity.name, activity.lastDone, activity.icon]
+    'INSERT INTO activities (id, name, lastDone, icon, orderIndex) VALUES (?, ?, ?, ?, ?)',
+    [activity.id, activity.name, activity.lastDone, activity.icon, activity.orderIndex]
   );
 };
 
@@ -184,9 +198,22 @@ export const updateActivity = async (activity: Activity) => {
   const db = await getDb();
   if (!db) return;
   await db.runAsync(
-    'UPDATE activities SET name = ?, lastDone = ?, icon = ? WHERE id = ?',
-    [activity.name, activity.lastDone, activity.icon, activity.id]
+    'UPDATE activities SET name = ?, lastDone = ?, icon = ?, orderIndex = ? WHERE id = ?',
+    [activity.name, activity.lastDone, activity.icon, activity.orderIndex, activity.id]
   );
+};
+
+export const updateActivitiesOrder = async (activities: Activity[]) => {
+  const db = await getDb();
+  if (!db) return;
+  await db.withTransactionAsync(async () => {
+    for (const activity of activities) {
+      await db.runAsync(
+        'UPDATE activities SET orderIndex = ? WHERE id = ?',
+        [activity.orderIndex, activity.id]
+      );
+    }
+  });
 };
 
 export const deleteActivity = async (id: string) => {

--- a/ActivityTracker/src/utils/database.web.ts
+++ b/ActivityTracker/src/utils/database.web.ts
@@ -46,9 +46,30 @@ const openDB = (): Promise<IDBDatabase> => {
 export const getDb = async () => {
   if (db) return db;
   db = await openDB();
+  await migrateDatabase(db);
   await migrateFromAsyncStorage(db);
   await seedInitialData(db);
   return db;
+};
+
+const migrateDatabase = async (db: IDBDatabase) => {
+    const activities = await getAllFromStore<Activity>(db, ACTIVITIES_STORE);
+    const needsMigration = activities.some(a => a.orderIndex === undefined);
+
+    if (needsMigration) {
+        console.log('Migrating IndexedDB activities: adding orderIndex...');
+        const tx = db.transaction(ACTIVITIES_STORE, 'readwrite');
+        const store = tx.objectStore(ACTIVITIES_STORE);
+        for (let i = 0; i < activities.length; i++) {
+            if (activities[i].orderIndex === undefined) {
+                store.put({ ...activities[i], orderIndex: i });
+            }
+        }
+        return new Promise<void>((resolve, reject) => {
+            tx.oncomplete = () => resolve();
+            tx.onerror = () => reject(tx.error);
+        });
+    }
 };
 
 export const initDatabase = async () => {

--- a/ActivityTracker/src/utils/database.web.ts
+++ b/ActivityTracker/src/utils/database.web.ts
@@ -60,8 +60,9 @@ const seedInitialData = async (db: IDBDatabase) => {
     if (activities.length === 0) {
         console.log('Seeding initial data to IndexedDB...');
         const tx = db.transaction([ACTIVITIES_STORE, ENTRIES_STORE], 'readwrite');
-        for (const activity of initialActivities) {
-            tx.objectStore(ACTIVITIES_STORE).add(activity);
+        for (let i = 0; i < initialActivities.length; i++) {
+            const activity = initialActivities[i];
+            tx.objectStore(ACTIVITIES_STORE).add({ ...activity, orderIndex: i });
             const entries = initialActivityDetails[activity.id] || [];
             for (const entry of entries) {
                 tx.objectStore(ENTRIES_STORE).add({ ...entry, activityId: activity.id });
@@ -86,8 +87,9 @@ const migrateFromAsyncStorage = async (db: IDBDatabase) => {
                 : {};
 
             const tx = db.transaction([ACTIVITIES_STORE, ENTRIES_STORE], 'readwrite');
-            for (const activity of activities) {
-                tx.objectStore(ACTIVITIES_STORE).put(activity);
+            for (let i = 0; i < activities.length; i++) {
+                const activity = activities[i];
+                tx.objectStore(ACTIVITIES_STORE).put({ ...activity, orderIndex: i });
                 const entries = activityDetails[activity.id] || [];
                 for (const entry of entries) {
                     tx.objectStore(ENTRIES_STORE).put({ ...entry, activityId: activity.id });
@@ -121,7 +123,8 @@ const getAllFromStore = <T>(db: IDBDatabase, storeName: string): Promise<T[]> =>
 
 export const getActivities = async (): Promise<Activity[]> => {
   const db = await getDb();
-  return getAllFromStore<Activity>(db, ACTIVITIES_STORE);
+  const activities = await getAllFromStore<Activity>(db, ACTIVITIES_STORE);
+  return activities.sort((a, b) => (a.orderIndex ?? 0) - (b.orderIndex ?? 0));
 };
 
 export const addActivity = async (activity: Activity): Promise<void> => {
@@ -139,6 +142,19 @@ export const updateActivity = async (activity: Activity): Promise<void> => {
   return new Promise((resolve, reject) => {
       const tx = db.transaction(ACTIVITIES_STORE, 'readwrite');
       tx.objectStore(ACTIVITIES_STORE).put(activity);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+  });
+};
+
+export const updateActivitiesOrder = async (activities: Activity[]): Promise<void> => {
+  const db = await getDb();
+  return new Promise((resolve, reject) => {
+      const tx = db.transaction(ACTIVITIES_STORE, 'readwrite');
+      const store = tx.objectStore(ACTIVITIES_STORE);
+      for (const activity of activities) {
+          store.put(activity);
+      }
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
   });

--- a/expo_web.log
+++ b/expo_web.log
@@ -1,0 +1,13 @@
+npm warn exec The following package was not found and will be installed: expo@55.0.4
+npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
+Starting project at /app/ActivityTracker
+ConfigError: Cannot determine the project's Expo SDK version because the module `expo` is not installed. Install it with `npm install expo` and try again.
+npm notice
+npm notice New minor version of npm available! 11.7.0 -> 11.11.0
+npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.11.0
+npm notice To update run: npm install -g npm@11.11.0
+npm notice


### PR DESCRIPTION
Implemented reordering of activities on the main screen and improved the behavior of edit mode.

Key changes:
1. **Persistence Layer**: Added an `orderIndex` field to the `activities` table in both SQLite (native) and IndexedDB (web). A migration path was added to ensure existing activities are assigned a default order.
2. **Reordering UI**: In edit mode, activities now display up and down arrow icons. These icons allow users to move activities within the list. The icons are automatically disabled when an activity is at the top or bottom of the current view.
3. **Edit Mode Improvements**:
   - The "Edit" button (pencil icon) is now disabled and grayed out if there are no activities to edit.
   - If a user deletes the last remaining activity while in edit mode, the app automatically exits edit mode and returns the header to its normal state.
4. **Logic & Performance**:
   - Reordering logic correctly handles the "Search" filter, ensuring that swapping items in a filtered view affects the correct activities.
   - Database updates for reordering are batched for better performance.
   - React state management follows best practices to avoid direct mutation.

---
*PR created automatically by Jules for task [10982799237861234621](https://jules.google.com/task/10982799237861234621) started by @malmiski*