### PR TITLE
Add support for multiple photos in activity entries

### DIFF
--- a/ActivityTracker/app/ActivityDetail.tsx
+++ b/ActivityTracker/app/ActivityDetail.tsx
@@ -98,8 +98,8 @@ const ActivityDetailScreen: React.FC = () => {
             startDate={item.startDate}
             endDate={item.endDate}
             notes={item.notes}
-            image={item.image}
-            thumbnail={item.thumbnail}
+            images={item.images}
+            thumbnails={item.thumbnails}
             imageMode={imageMode}
             tags={item.tags}
             onEdit={() => router.push(`/EditEntry?activityId=${activityId}&entryId=${item.id}`)}

--- a/ActivityTracker/app/EditEntry.tsx
+++ b/ActivityTracker/app/EditEntry.tsx
@@ -35,8 +35,7 @@ const EditEntryScreen: React.FC = () => {
   const [endAmpm, setEndAmpm] = useState('');
 
   const [notes, setNotes] = useState('');
-  const [image, setImage] = useState<string | undefined>(undefined);
-  const [thumbnail, setThumbnail] = useState<string | undefined>(undefined);
+  const [photos, setPhotos] = useState<{ image: string, thumbnail: string, orderStr: string }[]>([]);
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [tagSearch, setTagSearch] = useState('');
   const [isFormValidState, setIsFormValidState] = useState(false);
@@ -127,8 +126,24 @@ const EditEntryScreen: React.FC = () => {
       setEndAmpm(endAmpmVal);
 
       setNotes(entry.notes || '');
-      setImage(entry.image);
-      setThumbnail(entry.thumbnail);
+
+      const newPhotos: { image: string, thumbnail: string, orderStr: string }[] = [];
+      if (entry.images && entry.images.length > 0) {
+          for (let i = 0; i < entry.images.length; i++) {
+              newPhotos.push({
+                  image: entry.images[i],
+                  thumbnail: entry.thumbnails && entry.thumbnails[i] ? entry.thumbnails[i] : entry.images[i],
+                  orderStr: (i + 1).toString()
+              });
+          }
+      } else if (entry.image) {
+          newPhotos.push({
+              image: entry.image,
+              thumbnail: entry.thumbnail || entry.image,
+              orderStr: '1'
+          });
+      }
+      setPhotos(newPhotos);
       setSelectedTags(entry.tags || []);
     }
   }, [entry]);
@@ -137,21 +152,27 @@ const EditEntryScreen: React.FC = () => {
     setIsFormValidState(isFormValid());
   }, [year, month, day, hour, minute, second, ampm, endYear, endMonth, endDay, endHour, endMinute, endSecond, endAmpm]);
 
-  const handleImageInput = async (uri: string) => {
+  const handleImageInput = async (uri: string, replaceIndex: number = -1) => {
     try {
-      const [fullImage, thumbImage] = await Promise.all([
-        processImage(uri),
-        generateThumbnail(uri)
-      ]);
-      setImage(fullImage);
-      setThumbnail(thumbImage);
+      const processedUri = await processImage(uri);
+      const thumbImage = await generateThumbnail(processedUri);
+
+      setPhotos(prev => {
+          const newPhotos = [...prev];
+          if (replaceIndex >= 0 && replaceIndex < newPhotos.length) {
+              newPhotos[replaceIndex] = { ...newPhotos[replaceIndex], image: processedUri, thumbnail: thumbImage };
+          } else {
+              newPhotos.push({ image: processedUri, thumbnail: thumbImage, orderStr: (newPhotos.length + 1).toString() });
+          }
+          return newPhotos;
+      });
     } catch (e) {
       Alert.alert("Error processing image");
       console.error(e);
     }
   };
 
-  const pickImage = async () => {
+  const pickImage = async (replaceIndex: number = -1) => {
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ['images'],
       allowsEditing: true,
@@ -159,11 +180,11 @@ const EditEntryScreen: React.FC = () => {
     });
 
     if (!result.canceled && result.assets && result.assets[0].uri) {
-      await handleImageInput(result.assets[0].uri);
+      await handleImageInput(result.assets[0].uri, replaceIndex);
     }
   };
 
-  const pasteImage = async () => {
+  const pasteImage = async (replaceIndex: number = -1) => {
     const hasImage = await Clipboard.hasImageAsync();
     if (hasImage) {
       const imageBase64 = await Clipboard.getImageAsync({ format: 'png' }); // Clipboard currently only supports png/jpg
@@ -173,7 +194,7 @@ const EditEntryScreen: React.FC = () => {
         if (!uri.startsWith('data:')) {
             uri = `data:image/png;base64,${uri}`;
         }
-        await handleImageInput(uri);
+        await handleImageInput(uri, replaceIndex);
       }
     } else {
       Alert.alert("No image found in clipboard");
@@ -239,7 +260,9 @@ const EditEntryScreen: React.FC = () => {
     if (activityId && entryId && isFormValid()) {
       const startDate = getFullDate(year, month, day, hour, minute, second, ampm);
       const endDate = getFullDate(endYear, endMonth, endDay, endHour, endMinute, endSecond, endAmpm);
-      updateActivityEntry(activityId, entryId, startDate, endDate, notes, image, thumbnail, selectedTags);
+      const images = photos.length > 0 ? photos.map(p => p.image) : undefined;
+      const thumbnails = photos.length > 0 ? photos.map(p => p.thumbnail) : undefined;
+      updateActivityEntry(activityId, entryId, startDate, endDate, notes, images, thumbnails, selectedTags);
       if (router.canGoBack()) {
         router.back();
       } else {
@@ -501,28 +524,68 @@ const EditEntryScreen: React.FC = () => {
           onChangeText={setNotes}
           multiline
         />
-        <Text style={[styles.label, { marginTop: 20 }]}>Photo</Text>
-        <View style={styles.imageActions}>
-          <TouchableOpacity style={styles.imageButton} onPress={pickImage}>
-            <Icon name="image-plus" size={24} color={theme.colors.text} />
-            <Text style={styles.imageButtonText}>Upload</Text>
-          </TouchableOpacity>
-          <TouchableOpacity style={styles.imageButton} onPress={pasteImage}>
-            <Icon name="clipboard-arrow-down-outline" size={24} color={theme.colors.text} />
-            <Text style={styles.imageButtonText}>Paste</Text>
-          </TouchableOpacity>
-          {image && (
-            <TouchableOpacity style={styles.imageButton} onPress={() => { setImage(undefined); setThumbnail(undefined); }}>
-              <Icon name="delete-outline" size={24} color={theme.colors.error || '#FF3B30'} />
-              <Text style={[styles.imageButtonText, { color: theme.colors.error || '#FF3B30' }]}>Remove</Text>
+        <Text style={[styles.label, { marginTop: 20 }]}>Photos</Text>
+
+        {photos.length > 0 && (
+            <TouchableOpacity style={[styles.imageButton, { marginBottom: 15, justifyContent: 'center', backgroundColor: theme.colors.primary }]} onPress={() => {
+                const sorted = [...photos].sort((a, b) => {
+                    const numA = parseInt(a.orderStr) || 0;
+                    const numB = parseInt(b.orderStr) || 0;
+                    return numA - numB;
+                }).map((p, idx) => ({...p, orderStr: (idx + 1).toString()}));
+                setPhotos(sorted);
+            }}>
+                <Icon name="sort" size={20} color="#fff" />
+                <Text style={[styles.imageButtonText, { color: '#fff' }]}>Rearrange</Text>
             </TouchableOpacity>
-          )}
-        </View>
-        {image && (
-          <View style={styles.imagePreviewContainer}>
-            <Image source={{ uri: image }} style={styles.imagePreview} />
-          </View>
         )}
+
+        {photos.map((photo, index) => (
+            <View key={index} style={styles.photoItemContainer}>
+                <Image source={{ uri: photo.image }} style={styles.imagePreview} />
+                <View style={styles.photoControlsRow}>
+                    <View style={styles.orderContainer}>
+                        <Text style={styles.orderLabel}>Order:</Text>
+                        <TextInput
+                            style={styles.orderInput}
+                            value={photo.orderStr}
+                            onChangeText={(text) => {
+                                setPhotos(prev => {
+                                    const newPhotos = [...prev];
+                                    newPhotos[index].orderStr = text;
+                                    return newPhotos;
+                                });
+                            }}
+                            keyboardType="number-pad"
+                        />
+                    </View>
+                    <TouchableOpacity style={styles.photoControlButton} onPress={() => pickImage(index)}>
+                        <Icon name="upload" size={20} color={theme.colors.text} />
+                        <Text style={styles.photoControlText}>Upload</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity style={styles.photoControlButton} onPress={() => pasteImage(index)}>
+                        <Icon name="clipboard-outline" size={20} color={theme.colors.text} />
+                        <Text style={styles.photoControlText}>Paste</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity style={[styles.photoControlButton, { backgroundColor: '#FF3B30' + '20' }]} onPress={() => {
+                        setPhotos(prev => prev.filter((_, i) => i !== index));
+                    }}>
+                        <Icon name="delete" size={20} color="#FF3B30" />
+                    </TouchableOpacity>
+                </View>
+            </View>
+        ))}
+
+        <View style={styles.imageActions}>
+          <TouchableOpacity style={styles.imageButton} onPress={() => pickImage(-1)}>
+            <Icon name="image-plus" size={24} color={theme.colors.text} />
+            <Text style={styles.imageButtonText}>Add Photo</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.imageButton} onPress={() => pasteImage(-1)}>
+            <Icon name="clipboard-arrow-down-outline" size={24} color={theme.colors.text} />
+            <Text style={styles.imageButtonText}>Paste Photo</Text>
+          </TouchableOpacity>
+        </View>
         <View style={{ height: 40 }} />
       </ScrollView>
       <View style={styles.footer}>
@@ -765,6 +828,49 @@ const styles = StyleSheet.create({
     height: 200,
     borderRadius: 10,
     resizeMode: 'contain',
+  },
+  photoItemContainer: {
+    backgroundColor: theme.colors.card,
+    borderRadius: 15,
+    padding: 10,
+    marginBottom: 15,
+  },
+  photoControlsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 10,
+  },
+  orderContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  orderLabel: {
+    color: theme.colors.text,
+    marginRight: 5,
+    fontSize: 14,
+  },
+  orderInput: {
+    backgroundColor: theme.colors.background,
+    color: theme.colors.text,
+    borderRadius: 5,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    width: 40,
+    textAlign: 'center',
+  },
+  photoControlButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: theme.colors.background,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+    gap: 4,
+  },
+  photoControlText: {
+    color: theme.colors.text,
+    fontSize: 12,
   },
   footer: {
     padding: 20,

--- a/ActivityTracker/src/components/ActivityHistoryItem.tsx
+++ b/ActivityTracker/src/components/ActivityHistoryItem.tsx
@@ -100,15 +100,25 @@ const ActivityHistoryItem: React.FC<ActivityHistoryItemProps> = ({
       const source = { uri: targetImage.startsWith('data:') ? targetImage : `data:image/jpeg;base64,${targetImage}` };
 
       return (
-        <View style={{ position: 'relative', width: '100%' }}>
+                <View style={{ position: 'relative', width: '100%' }}>
             <Image source={source} style={styles.thumbnailLarge} />
             {itemsToRender.length > 1 && (
-                <TouchableOpacity
-                    style={{ position: 'absolute', right: 10, top: '50%', marginTop: -20, backgroundColor: 'rgba(255,255,255,0.7)', borderRadius: 20, padding: 5 }}
-                    onPress={() => setCurrentImageIndex((prev) => (prev + 1) % itemsToRender.length)}
-                >
-                    <Icon name="chevron-right" size={30} color="#000" />
-                </TouchableOpacity>
+                <>
+                    <TouchableOpacity
+                        style={{ position: 'absolute', left: 10, top: '50%', marginTop: -20, backgroundColor: currentImageIndex === 0 ? 'rgba(255,255,255,0.3)' : 'rgba(255,255,255,0.7)', borderRadius: 20, padding: 5 }}
+                        onPress={() => setCurrentImageIndex((prev) => prev - 1)}
+                        disabled={currentImageIndex === 0}
+                    >
+                        <Icon name="chevron-left" size={30} color={currentImageIndex === 0 ? 'rgba(0,0,0,0.3)' : '#000'} />
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                        style={{ position: 'absolute', right: 10, top: '50%', marginTop: -20, backgroundColor: currentImageIndex === itemsToRender.length - 1 ? 'rgba(255,255,255,0.3)' : 'rgba(255,255,255,0.7)', borderRadius: 20, padding: 5 }}
+                        onPress={() => setCurrentImageIndex((prev) => prev + 1)}
+                        disabled={currentImageIndex === itemsToRender.length - 1}
+                    >
+                        <Icon name="chevron-right" size={30} color={currentImageIndex === itemsToRender.length - 1 ? 'rgba(0,0,0,0.3)' : '#000'} />
+                    </TouchableOpacity>
+                </>
             )}
         </View>
       );

--- a/ActivityTracker/src/components/ActivityHistoryItem.tsx
+++ b/ActivityTracker/src/components/ActivityHistoryItem.tsx
@@ -64,7 +64,7 @@ const ActivityHistoryItem: React.FC<ActivityHistoryItemProps> = ({
     if ((!image && !validThumbnail) || imageMode === 'hidden') return null;
 
     let targetImage = image;
-    if ((imageMode === 'small' || imageMode === 'medium') && validThumbnail) {
+    if ((imageMode === 'small' || imageMode === 'medium' || imageMode === 'large') && validThumbnail) {
        targetImage = validThumbnail;
     }
 

--- a/ActivityTracker/src/components/ActivityHistoryItem.tsx
+++ b/ActivityTracker/src/components/ActivityHistoryItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Image, ScrollView } from 'react-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import theme from '../theme/theme';
@@ -10,8 +10,8 @@ interface ActivityHistoryItemProps {
   startDate: Date;
   endDate: Date;
   notes?: string;
-  image?: string;
-  thumbnail?: string;
+  images?: string[];
+  thumbnails?: string[];
   onEdit: () => void;
   onDelete: () => void;
   imageMode?: ImageMode;
@@ -48,53 +48,83 @@ const ActivityHistoryItem: React.FC<ActivityHistoryItemProps> = ({
   startDate,
   endDate,
   notes,
-  image,
-  thumbnail,
+  images,
+  thumbnails,
   onEdit,
   onDelete,
   imageMode = 'small',
   tags = []
 }) => {
+  const [currentImageIndex, setCurrentImageIndex] = useState(0);
+
   const firstLine = notes ? notes.split('\n')[0] : '';
   const duration = formatDuration(startDate, endDate);
   const isDifferentDate = startDate.getTime() !== endDate.getTime();
 
-  const renderImage = () => {
-    const validThumbnail = thumbnail && thumbnail !== "failed" ? thumbnail : undefined;
-    if ((!image && !validThumbnail) || imageMode === 'hidden') return null;
+  const renderImages = () => {
+    if (imageMode === 'hidden' || (!images && !thumbnails)) return null;
 
-    let targetImage = image;
-    if ((imageMode === 'small' || imageMode === 'medium' || imageMode === 'large') && validThumbnail) {
-       targetImage = validThumbnail;
+    const availableImages = images && images.length > 0 ? images : null;
+    const availableThumbnails = thumbnails && thumbnails.length > 0 ? thumbnails : null;
+
+    if (!availableImages && !availableThumbnails) return null;
+
+    if (imageMode === 'small' || imageMode === 'medium') {
+      const isMultiple = (availableImages && availableImages.length > 1) || (availableThumbnails && availableThumbnails.length > 1);
+      const itemsToRender = availableThumbnails || availableImages || [];
+
+      const elements = itemsToRender.map((imgStr, idx) => {
+         if (imgStr === "failed") return null;
+         const source = { uri: imgStr.startsWith('data:') ? imgStr : `data:image/jpeg;base64,${imgStr}` };
+         return <Image key={idx} source={source} style={imageMode === 'medium' ? styles.thumbnailMedium : styles.thumbnailSmall} />;
+      });
+
+      if (isMultiple) {
+         return (
+             <ScrollView horizontal showsHorizontalScrollIndicator={false} style={{ marginBottom: 15, width: '100%' }}>
+                 {elements}
+             </ScrollView>
+         );
+      } else {
+         return elements[0];
+      }
     }
 
-    if (!targetImage || targetImage === "failed") return null;
+    // Large Mode
+    if (imageMode === 'large') {
+      const itemsToRender = availableImages || availableThumbnails || [];
+      if (!itemsToRender || itemsToRender.length === 0) return null;
 
-    const source = { uri: targetImage.startsWith('data:') ? targetImage : `data:image/jpeg;base64,${targetImage}` };
+      const targetImage = itemsToRender[currentImageIndex];
+      if (!targetImage || targetImage === "failed") return null;
+      const source = { uri: targetImage.startsWith('data:') ? targetImage : `data:image/jpeg;base64,${targetImage}` };
 
-    let imageStyle;
-    switch (imageMode) {
-      case 'medium':
-        imageStyle = styles.thumbnailMedium;
-        break;
-      case 'large':
-        imageStyle = styles.thumbnailLarge;
-        break;
-      case 'small':
-      default:
-        imageStyle = styles.thumbnailSmall;
-        break;
+      return (
+        <View style={{ position: 'relative', width: '100%' }}>
+            <Image source={source} style={styles.thumbnailLarge} />
+            {itemsToRender.length > 1 && (
+                <TouchableOpacity
+                    style={{ position: 'absolute', right: 10, top: '50%', marginTop: -20, backgroundColor: 'rgba(255,255,255,0.7)', borderRadius: 20, padding: 5 }}
+                    onPress={() => setCurrentImageIndex((prev) => (prev + 1) % itemsToRender.length)}
+                >
+                    <Icon name="chevron-right" size={30} color="#000" />
+                </TouchableOpacity>
+            )}
+        </View>
+      );
     }
 
-    return <Image source={source} style={imageStyle} />;
+    return null;
   };
 
-  const isLarge = imageMode === 'large' && image;
+  const isLarge = imageMode === 'large' && ((images && images.length > 0) || (thumbnails && thumbnails.length > 0));
+  const hasMultipleInRow = (imageMode === 'small' || imageMode === 'medium') && ((images && images.length > 1) || (thumbnails && thumbnails.length > 1));
 
   return (
-    <View style={[styles.container, isLarge && styles.containerLarge]}>
-      {renderImage()}
-      <View style={styles.contentWrapper}>
+    <View style={[styles.container, (isLarge || hasMultipleInRow) && styles.containerLarge]}>
+      {(isLarge || hasMultipleInRow) ? renderImages() : null}
+      <View style={[styles.contentWrapper, hasMultipleInRow && { marginTop: 0 }]}>
+        {!(isLarge || hasMultipleInRow) ? renderImages() : null}
         <View style={styles.textContainer}>
           <Text style={styles.dateText}>
             {formatDate(startDate)}

--- a/ActivityTracker/src/components/__snapshots__/ActivityHistoryItem.test.tsx.snap
+++ b/ActivityTracker/src/components/__snapshots__/ActivityHistoryItem.test.tsx.snap
@@ -13,18 +13,21 @@ exports[`ActivityHistoryItem only renders the first line of multi-line notes 1`]
         "marginBottom": 15,
         "padding": 15,
       },
-      false,
+      undefined,
     ]
   }
 >
   <View
     style={
-      {
-        "alignItems": "center",
-        "flex": 1,
-        "flexDirection": "row",
-        "justifyContent": "space-between",
-      }
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
     <View
@@ -171,12 +174,15 @@ exports[`ActivityHistoryItem renders correctly with an image and hidden imageMod
 >
   <View
     style={
-      {
-        "alignItems": "center",
-        "flex": 1,
-        "flexDirection": "row",
-        "justifyContent": "space-between",
-      }
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        },
+        false,
+      ]
     }
   >
     <View
@@ -304,36 +310,21 @@ exports[`ActivityHistoryItem renders correctly with an image and large imageMode
         "marginBottom": 15,
         "padding": 15,
       },
-      {
-        "alignItems": "stretch",
-        "flexDirection": "column",
-      },
+      false,
     ]
   }
 >
-  <Image
-    source={
-      {
-        "uri": "data:image/jpeg;base64,mock",
-      }
-    }
-    style={
-      {
-        "borderRadius": 10,
-        "height": 200,
-        "marginBottom": 15,
-        "width": "100%",
-      }
-    }
-  />
   <View
     style={
-      {
-        "alignItems": "center",
-        "flex": 1,
-        "flexDirection": "row",
-        "justifyContent": "space-between",
-      }
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        },
+        false,
+      ]
     }
   >
     <View
@@ -461,33 +452,21 @@ exports[`ActivityHistoryItem renders correctly with an image and medium imageMod
         "marginBottom": 15,
         "padding": 15,
       },
-      false,
+      undefined,
     ]
   }
 >
-  <Image
-    source={
-      {
-        "uri": "data:image/jpeg;base64,mock",
-      }
-    }
-    style={
-      {
-        "borderRadius": 10,
-        "height": 100,
-        "marginRight": 15,
-        "width": 100,
-      }
-    }
-  />
   <View
     style={
-      {
-        "alignItems": "center",
-        "flex": 1,
-        "flexDirection": "row",
-        "justifyContent": "space-between",
-      }
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
     <View
@@ -615,33 +594,21 @@ exports[`ActivityHistoryItem renders correctly with an image and small imageMode
         "marginBottom": 15,
         "padding": 15,
       },
-      false,
+      undefined,
     ]
   }
 >
-  <Image
-    source={
-      {
-        "uri": "data:image/jpeg;base64,mock",
-      }
-    }
-    style={
-      {
-        "borderRadius": 5,
-        "height": 50,
-        "marginRight": 15,
-        "width": 50,
-      }
-    }
-  />
   <View
     style={
-      {
-        "alignItems": "center",
-        "flex": 1,
-        "flexDirection": "row",
-        "justifyContent": "space-between",
-      }
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
     <View
@@ -769,18 +736,21 @@ exports[`ActivityHistoryItem renders correctly with notes preview 1`] = `
         "marginBottom": 15,
         "padding": 15,
       },
-      false,
+      undefined,
     ]
   }
 >
   <View
     style={
-      {
-        "alignItems": "center",
-        "flex": 1,
-        "flexDirection": "row",
-        "justifyContent": "space-between",
-      }
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
     <View
@@ -921,18 +891,21 @@ exports[`ActivityHistoryItem renders correctly without notes 1`] = `
         "marginBottom": 15,
         "padding": 15,
       },
-      false,
+      undefined,
     ]
   }
 >
   <View
     style={
-      {
-        "alignItems": "center",
-        "flex": 1,
-        "flexDirection": "row",
-        "justifyContent": "space-between",
-      }
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
     <View
@@ -1060,18 +1033,21 @@ exports[`ActivityHistoryItem renders duration when startDate and endDate differ 
         "marginBottom": 15,
         "padding": 15,
       },
-      false,
+      undefined,
     ]
   }
 >
   <View
     style={
-      {
-        "alignItems": "center",
-        "flex": 1,
-        "flexDirection": "row",
-        "justifyContent": "space-between",
-      }
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+        },
+        undefined,
+      ]
     }
   >
     <View

--- a/ActivityTracker/src/data/activity-details.ts
+++ b/ActivityTracker/src/data/activity-details.ts
@@ -9,8 +9,8 @@ export interface ActivityEntry {
   startDate: Date;
   endDate: Date;
   notes?: string;
-  image?: string; // base64 encoded image
-  thumbnail?: string; // base64 encoded smaller image
+  images?: string[]; // base64 encoded image
+  thumbnails?: string[]; // base64 encoded smaller image
   tags?: Tag[];
 }
 

--- a/ActivityTracker/src/hooks/useActivityData.ts
+++ b/ActivityTracker/src/hooks/useActivityData.ts
@@ -111,14 +111,14 @@ export const useActivityData = () => {
     await database.updateActivitiesOrder(newActivities);
   };
 
-  const addActivityEntry = async (activityId: string, startDate: Date, endDate: Date, notes?: string, image?: string, thumbnail?: string, entryTags?: Tag[]) => {
+  const addActivityEntry = async (activityId: string, startDate: Date, endDate: Date, notes?: string, images?: string[], thumbnails?: string[], entryTags?: Tag[]) => {
     const newEntry: ActivityEntry = {
-      id: await generateActivityId(Math.random().toString()),
-      startDate: startDate,
-      endDate: endDate,
+      id: await generateActivityId(activityId + startDate.getTime().toString()),
+      startDate,
+      endDate,
       notes: notes,
-      image: image,
-      thumbnail: thumbnail,
+      images: images,
+      thumbnails: thumbnails,
       tags: entryTags,
     };
 
@@ -140,17 +140,17 @@ export const useActivityData = () => {
     return newEntry.id;
   };
 
-  const updateActivityEntry = async (activityId: string, entryId: string, startDate: Date, endDate: Date, notes?: string, image?: string, thumbnail?: string, entryTags?: Tag[]) => {
-    const entry: ActivityEntry = {
+  const updateActivityEntry = async (activityId: string, entryId: string, startDate: Date, endDate: Date, notes?: string, images?: string[], thumbnails?: string[], entryTags?: Tag[]) => {
+    const updatedEntry: ActivityEntry = {
         id: entryId,
-        startDate: startDate,
-        endDate: endDate,
+        startDate,
+        endDate,
         notes: notes,
-        image: image,
-        thumbnail: thumbnail,
+        images: images,
+        thumbnails: thumbnails,
         tags: entryTags,
     };
-    await database.updateEntry(entry);
+    await database.updateEntry(updatedEntry);
 
     setActivityDetails(prev => {
       const updated = { ...prev };

--- a/ActivityTracker/src/utils/csv.ts
+++ b/ActivityTracker/src/utils/csv.ts
@@ -39,8 +39,8 @@ export const downloadCsv = async () => {
           new Date(detail.startDate).toISOString(),
           new Date(detail.endDate).toISOString(),
           detail.notes || '',
-          detail.image || '',
-          detail.thumbnail || '',
+          (detail.images || []).join('|'),
+          (detail.thumbnails || []).join('|'),
           tagsString
         ].map(escapeCSV).join(',');
         csvContent += row + '\n';
@@ -135,34 +135,34 @@ export const uploadCsv = async () => {
       if (!line || line.trim() === '') continue;
       const values = parseCSVLine(line);
 
-      let activityId, activityName, icon, entryId, startDateString, endDateString, notes, image, thumbnail, tagsString;
+      let activityId, activityName, icon, entryId, startDateString, endDateString, notes, imagesStr, thumbnailsStr, tagsString;
 
       if (hasIds) {
         if (hasEndDate) {
             if (hasTags) {
                 if (header.includes('Thumbnail')) {
                   if (values.length < 10) continue;
-                  [activityId, activityName, icon, entryId, startDateString, endDateString, notes, image, thumbnail, tagsString] = values;
+                  [activityId, activityName, icon, entryId, startDateString, endDateString, notes, imagesStr, thumbnailsStr, tagsString] = values;
                 } else {
                   if (values.length < 9) continue;
-                  [activityId, activityName, icon, entryId, startDateString, endDateString, notes, image, tagsString] = values;
+                  [activityId, activityName, icon, entryId, startDateString, endDateString, notes, imagesStr, tagsString] = values;
                 }
             } else {
                 if (values.length < 8) continue;
-                [activityId, activityName, icon, entryId, startDateString, endDateString, notes, image] = values;
+                [activityId, activityName, icon, entryId, startDateString, endDateString, notes, imagesStr] = values;
             }
         } else {
             if (values.length < 7) continue;
-            [activityId, activityName, icon, entryId, startDateString, notes, image] = values;
+            [activityId, activityName, icon, entryId, startDateString, notes, imagesStr] = values;
             endDateString = startDateString;
         }
       } else {
         if (hasEndDate) {
             if (values.length < 6) continue;
-            [activityName, icon, startDateString, endDateString, notes, image] = values;
+            [activityName, icon, startDateString, endDateString, notes, imagesStr] = values;
         } else {
             if (values.length < 5) continue;
-            [activityName, icon, startDateString, notes, image] = values;
+            [activityName, icon, startDateString, notes, imagesStr] = values;
             endDateString = startDateString;
         }
         activityId = await generateActivityId(activityName);
@@ -212,6 +212,9 @@ export const uploadCsv = async () => {
           }
       }
 
+      const images = imagesStr ? imagesStr.split('|').filter(Boolean) : undefined;
+      const thumbnails = thumbnailsStr ? thumbnailsStr.split('|').filter(Boolean) : undefined;
+
       const startDate = new Date(startDateString);
       const endDate = new Date(endDateString);
       const activityEntries = await database.getEntries(activityId);
@@ -223,8 +226,8 @@ export const uploadCsv = async () => {
           startDate,
           endDate,
           notes: notes || undefined,
-          image: image || undefined,
-          thumbnail: thumbnail || undefined,
+          images,
+          thumbnails,
           tags: entryTags,
         });
       } else {
@@ -233,8 +236,8 @@ export const uploadCsv = async () => {
           startDate,
           endDate,
           notes: notes || existingEntry.notes,
-          image: image || existingEntry.image,
-          thumbnail: thumbnail || existingEntry.thumbnail,
+          images: images || existingEntry.images,
+          thumbnails: thumbnails || existingEntry.thumbnails,
           tags: entryTags,
         });
       }

--- a/ActivityTracker/src/utils/database.ts
+++ b/ActivityTracker/src/utils/database.ts
@@ -229,6 +229,17 @@ export const deleteActivity = async (id: string) => {
   await db.runAsync('DELETE FROM activities WHERE id = ?', [id]);
 };
 
+const parseJsonArray = (str) => {
+    if (!str) return undefined;
+    try {
+        const parsed = JSON.parse(str);
+        if (Array.isArray(parsed)) return parsed;
+        return [str];
+    } catch (e) {
+        return [str];
+    }
+};
+
 const mapEntriesWithTags = (rows: any[]): ActivityEntry[] => {
     const entryMap = new Map<string, ActivityEntry>();
     rows.forEach(row => {
@@ -238,8 +249,8 @@ const mapEntriesWithTags = (rows: any[]): ActivityEntry[] => {
                 startDate: new Date(row.startDate),
                 endDate: new Date(row.endDate),
                 notes: row.notes,
-                image: row.image,
-                thumbnail: row.thumbnail,
+                images: parseJsonArray(row.image),
+                thumbnails: parseJsonArray(row.thumbnail),
                 tags: []
             });
         }
@@ -287,8 +298,8 @@ export const getAllEntries = async (): Promise<(ActivityEntry & { activityId: st
               startDate: new Date(row.startDate),
               endDate: new Date(row.endDate),
               notes: row.notes,
-              image: row.image,
-              thumbnail: row.thumbnail,
+              images: parseJsonArray(row.image),
+              thumbnails: parseJsonArray(row.thumbnail),
               tags: []
           });
       }
@@ -308,7 +319,7 @@ export const addEntry = async (activityId: string, entry: ActivityEntry) => {
   if (!db) return;
   await db.runAsync(
     'INSERT INTO entries (id, activityId, startDate, endDate, notes, image, thumbnail) VALUES (?, ?, ?, ?, ?, ?, ?)',
-    [entry.id, activityId, entry.startDate.toISOString(), entry.endDate.toISOString(), entry.notes || null, entry.image || null, entry.thumbnail || null]
+    [entry.id, activityId, entry.startDate.toISOString(), entry.endDate.toISOString(), entry.notes || null, entry.images ? JSON.stringify(entry.images) : null, entry.thumbnails ? JSON.stringify(entry.thumbnails) : null]
   );
   if (entry.tags) {
     for (const tag of entry.tags) {
@@ -317,12 +328,12 @@ export const addEntry = async (activityId: string, entry: ActivityEntry) => {
   }
 };
 
-export const updateEntryImages = async (id: string, image?: string, thumbnail?: string) => {
+export const updateEntryImages = async (id: string, images?: string[], thumbnails?: string[]) => {
   const db = await getDb();
   if (!db) return;
   await db.runAsync(
     'UPDATE entries SET image = ?, thumbnail = ? WHERE id = ?',
-    [image ?? null, thumbnail ?? null, id]
+    [images ? JSON.stringify(images) : null, thumbnails ? JSON.stringify(thumbnails) : null, id]
   );
 };
 
@@ -331,7 +342,7 @@ export const updateEntry = async (entry: ActivityEntry) => {
   if (!db) return;
   await db.runAsync(
     'UPDATE entries SET startDate = ?, endDate = ?, notes = ?, image = ?, thumbnail = ? WHERE id = ?',
-    [entry.startDate.toISOString(), entry.endDate.toISOString(), entry.notes || null, entry.image ?? null, entry.thumbnail ?? null, entry.id]
+    [entry.startDate.toISOString(), entry.endDate.toISOString(), entry.notes || null, entry.images ? JSON.stringify(entry.images) : null, entry.thumbnails ? JSON.stringify(entry.thumbnails) : null, entry.id]
   );
   if (entry.tags) {
     await db.runAsync('DELETE FROM entry_tags WHERE entryId = ?', [entry.id]);
@@ -424,8 +435,8 @@ export const getEntriesByTag = async (tagId: string): Promise<(ActivityEntry & {
                 startDate: new Date(row.startDate),
                 endDate: new Date(row.endDate),
                 notes: row.notes,
-                image: row.image,
-                thumbnail: row.thumbnail,
+                images: parseJsonArray(row.image),
+              thumbnails: parseJsonArray(row.thumbnail),
                 tags: []
             });
         }

--- a/ActivityTracker/src/utils/database.web.ts
+++ b/ActivityTracker/src/utils/database.web.ts
@@ -87,6 +87,7 @@ const migrateDatabase = async (db: IDBDatabase) => {
                 }
             };
 
+
             entries.forEach((entry: any) => {
                 let needsUpdate = false;
                 if (entry.date && !entry.startDate) {
@@ -94,6 +95,15 @@ const migrateDatabase = async (db: IDBDatabase) => {
                     entry.endDate = entry.date;
                     needsUpdate = true;
                 }
+                if (entry.image !== undefined && entry.images === undefined) {
+                    entry.images = entry.image ? [entry.image] : undefined;
+                    needsUpdate = true;
+                }
+                if (entry.thumbnail !== undefined && entry.thumbnails === undefined) {
+                    entry.thumbnails = entry.thumbnail ? [entry.thumbnail] : undefined;
+                    needsUpdate = true;
+                }
+
 
                 if (needsUpdate) {
                     pendingUpdates++;
@@ -272,11 +282,23 @@ const fetchTagsForEntries = async (db: IDBDatabase, entries: any[]): Promise<any
             });
             if (tag) tags.push(tag);
         }
+
+        let images = row.images;
+        if (row.image !== undefined && images === undefined) {
+            images = row.image ? [row.image] : undefined;
+        }
+        let thumbnails = row.thumbnails;
+        if (row.thumbnail !== undefined && thumbnails === undefined) {
+            thumbnails = row.thumbnail ? [row.thumbnail] : undefined;
+        }
+
         results.push({
             ...row,
             startDate: new Date(row.startDate || row.date),
             endDate: new Date(row.endDate || row.date),
             tags: tags,
+            images,
+            thumbnails,
         });
     }
     return results;
@@ -320,20 +342,24 @@ export const addEntry = async (activityId: string, entry: ActivityEntry): Promis
   });
 };
 
-export const updateEntryImages = async (id: string, image?: string, thumbnail?: string): Promise<void> => {
-  const db = await getDb();
-  return new Promise((resolve, reject) => {
-      const tx = db.transaction([ENTRIES_STORE], 'readwrite');
-      const store = tx.objectStore(ENTRIES_STORE);
-      const getReq = store.get(id);
-      getReq.onsuccess = () => {
-          if (getReq.result) {
-              store.put({ ...getReq.result, image, thumbnail });
-          }
-      };
-      tx.oncomplete = () => resolve();
-      tx.onerror = () => reject(tx.error);
-  });
+export const updateEntryImages = async (id: string, images?: string[], thumbnails?: string[]): Promise<void> => {
+    const db = await getDb();
+    if (!db) return;
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(ENTRIES_STORE, 'readwrite');
+        const store = tx.objectStore(ENTRIES_STORE);
+        const req = store.get(id);
+        req.onsuccess = () => {
+            const entry = req.result;
+            if (entry) {
+                entry.images = images;
+                entry.thumbnails = thumbnails;
+                store.put(entry);
+            }
+        };
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
 };
 
 export const updateEntry = async (entry: ActivityEntry): Promise<void> => {


### PR DESCRIPTION
This updates the data schema to support multiple photos, updates the `EditEntry` UI to support adding, removing, and reordering the photos, and finally updates the `ActivityHistoryItem` to accurately display the new images list depending on the size mode.

---
*PR created automatically by Jules for task [5048518039512845984](https://jules.google.com/task/5048518039512845984) started by @malmiski*