### PR TITLE
Improve large image gallery with scrolling and proportional auto height

### DIFF
--- a/ActivityTracker/src/components/ActivityHistoryItem.tsx
+++ b/ActivityTracker/src/components/ActivityHistoryItem.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity, Image, ScrollView } from 'rea
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import theme from '../theme/theme';
 import { Tag } from '../data/activity-details';
+import LargeImageGallery from './LargeImageGallery';
 
 export type ImageMode = 'small' | 'medium' | 'large' | 'hidden';
 
@@ -55,8 +56,6 @@ const ActivityHistoryItem: React.FC<ActivityHistoryItemProps> = ({
   imageMode = 'small',
   tags = []
 }) => {
-  const [currentImageIndex, setCurrentImageIndex] = useState(0);
-
   const firstLine = notes ? notes.split('\n')[0] : '';
   const duration = formatDuration(startDate, endDate);
   const isDifferentDate = startDate.getTime() !== endDate.getTime();
@@ -95,33 +94,7 @@ const ActivityHistoryItem: React.FC<ActivityHistoryItemProps> = ({
       const itemsToRender = availableImages || availableThumbnails || [];
       if (!itemsToRender || itemsToRender.length === 0) return null;
 
-      const targetImage = itemsToRender[currentImageIndex];
-      if (!targetImage || targetImage === "failed") return null;
-      const source = { uri: targetImage.startsWith('data:') ? targetImage : `data:image/jpeg;base64,${targetImage}` };
-
-      return (
-                <View style={{ position: 'relative', width: '100%' }}>
-            <Image source={source} style={styles.thumbnailLarge} />
-            {itemsToRender.length > 1 && (
-                <>
-                    <TouchableOpacity
-                        style={{ position: 'absolute', left: 10, top: '50%', marginTop: -20, backgroundColor: currentImageIndex === 0 ? 'rgba(255,255,255,0.3)' : 'rgba(255,255,255,0.7)', borderRadius: 20, padding: 5 }}
-                        onPress={() => setCurrentImageIndex((prev) => prev - 1)}
-                        disabled={currentImageIndex === 0}
-                    >
-                        <Icon name="chevron-left" size={30} color={currentImageIndex === 0 ? 'rgba(0,0,0,0.3)' : '#000'} />
-                    </TouchableOpacity>
-                    <TouchableOpacity
-                        style={{ position: 'absolute', right: 10, top: '50%', marginTop: -20, backgroundColor: currentImageIndex === itemsToRender.length - 1 ? 'rgba(255,255,255,0.3)' : 'rgba(255,255,255,0.7)', borderRadius: 20, padding: 5 }}
-                        onPress={() => setCurrentImageIndex((prev) => prev + 1)}
-                        disabled={currentImageIndex === itemsToRender.length - 1}
-                    >
-                        <Icon name="chevron-right" size={30} color={currentImageIndex === itemsToRender.length - 1 ? 'rgba(0,0,0,0.3)' : '#000'} />
-                    </TouchableOpacity>
-                </>
-            )}
-        </View>
-      );
+      return <LargeImageGallery items={itemsToRender} />;
     }
 
     return null;
@@ -200,12 +173,6 @@ const styles = StyleSheet.create({
     height: 100,
     borderRadius: 10,
     marginRight: 15,
-  },
-  thumbnailLarge: {
-    width: '100%',
-    height: 200,
-    borderRadius: 10,
-    marginBottom: 15,
   },
   dateText: {
     color: theme.colors.text,

--- a/ActivityTracker/src/components/AutoHeightImage.tsx
+++ b/ActivityTracker/src/components/AutoHeightImage.tsx
@@ -1,0 +1,37 @@
+import React, { useState, useEffect } from 'react';
+import { Image, ImageStyle, StyleProp } from 'react-native';
+
+interface AutoHeightImageProps {
+  source: { uri: string };
+  width: number;
+  style?: StyleProp<ImageStyle>;
+}
+
+const AutoHeightImage: React.FC<AutoHeightImageProps> = ({ source, width, style }) => {
+  const [aspectRatio, setAspectRatio] = useState(1);
+
+  useEffect(() => {
+    if (source.uri) {
+      Image.getSize(
+        source.uri,
+        (w, h) => {
+          if (w && h) {
+            setAspectRatio(w / h);
+          }
+        },
+        (error) => {
+          console.warn('Failed to get image size', error);
+        }
+      );
+    }
+  }, [source.uri]);
+
+  return (
+    <Image
+      source={source}
+      style={[{ width, aspectRatio, resizeMode: 'contain' }, style]}
+    />
+  );
+};
+
+export default AutoHeightImage;

--- a/ActivityTracker/src/components/LargeImageGallery.tsx
+++ b/ActivityTracker/src/components/LargeImageGallery.tsx
@@ -1,0 +1,77 @@
+import React, { useState, useRef } from 'react';
+import { View, ScrollView, TouchableOpacity } from 'react-native';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
+import AutoHeightImage from './AutoHeightImage';
+
+interface LargeImageGalleryProps {
+  items: string[];
+}
+
+const LargeImageGallery: React.FC<LargeImageGalleryProps> = ({ items }) => {
+  const [containerWidth, setContainerWidth] = useState(0);
+  const scrollViewRef = useRef<ScrollView>(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handleScroll = (event: any) => {
+    if (containerWidth > 0) {
+      const x = event.nativeEvent.contentOffset.x;
+      const index = Math.round(x / containerWidth);
+      if (index !== currentIndex) {
+        setCurrentIndex(index);
+      }
+    }
+  };
+
+  return (
+    <View
+      style={{ position: 'relative', width: '100%', marginBottom: 15 }}
+      onLayout={(e) => setContainerWidth(e.nativeEvent.layout.width)}
+    >
+      {containerWidth > 0 && (
+        <ScrollView
+          ref={scrollViewRef}
+          horizontal
+          pagingEnabled
+          showsHorizontalScrollIndicator={false}
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
+        >
+          {items.map((item, idx) => {
+            if (item === "failed") return null;
+            const source = { uri: item.startsWith('data:') ? item : `data:image/jpeg;base64,${item}` };
+            return <AutoHeightImage key={idx} source={source} width={containerWidth} style={{ borderRadius: 10 }} />;
+          })}
+        </ScrollView>
+      )}
+
+      {items.length > 1 && (
+        <>
+          <TouchableOpacity
+            style={{ position: 'absolute', left: 10, top: '50%', marginTop: -20, backgroundColor: currentIndex === 0 ? 'rgba(255,255,255,0.3)' : 'rgba(255,255,255,0.7)', borderRadius: 20, padding: 5 }}
+            onPress={() => {
+               if (currentIndex > 0) {
+                 scrollViewRef.current?.scrollTo({ x: (currentIndex - 1) * containerWidth, animated: true });
+               }
+            }}
+            disabled={currentIndex === 0}
+          >
+            <Icon name="chevron-left" size={30} color={currentIndex === 0 ? 'rgba(0,0,0,0.3)' : '#000'} />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={{ position: 'absolute', right: 10, top: '50%', marginTop: -20, backgroundColor: currentIndex === items.length - 1 ? 'rgba(255,255,255,0.3)' : 'rgba(255,255,255,0.7)', borderRadius: 20, padding: 5 }}
+            onPress={() => {
+               if (currentIndex < items.length - 1) {
+                 scrollViewRef.current?.scrollTo({ x: (currentIndex + 1) * containerWidth, animated: true });
+               }
+            }}
+            disabled={currentIndex === items.length - 1}
+          >
+            <Icon name="chevron-right" size={30} color={currentIndex === items.length - 1 ? 'rgba(0,0,0,0.3)' : '#000'} />
+          </TouchableOpacity>
+        </>
+      )}
+    </View>
+  );
+};
+
+export default LargeImageGallery;

--- a/expo_web.log
+++ b/expo_web.log
@@ -1,0 +1,3 @@
+npm warn exec The following package was not found and will be installed: expo@57.0.2
+npm warn deprecated uuid@7.0.3: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+ConfigError: The expected package.json path: /app/package.json does not exist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Implements a proper scrolling image gallery for the `large` image mode in the history log.
- Wrap images in a paging `ScrollView` for horizontal swiping
- Hook left/right navigation arrows to `.scrollTo()` in the ref
- Create `AutoHeightImage` helper that uses `Image.getSize()` to dynamically adjust image height based on the available width without clipping.

---
*PR created automatically by Jules for task [9952486887627755172](https://jules.google.com/task/9952486887627755172) started by @malmiski*