### PR TITLE
Fix flatlist scrolling delay on Activity Detail Screen

### DIFF
--- a/ActivityTracker/app/ActivityDetail.tsx
+++ b/ActivityTracker/app/ActivityDetail.tsx
@@ -36,7 +36,7 @@ const ActivityDetailScreen: React.FC = () => {
   const scrollToRandom = () => {
     if (filteredHistory.length > 0) {
       const randomIndex = Math.floor(Math.random() * filteredHistory.length);
-      flatListRef.current?.scrollToIndex({ index: randomIndex, animated: true });
+      flatListRef.current?.scrollToIndex({ index: randomIndex, animated: false });
     }
   };
 
@@ -112,10 +112,10 @@ const ActivityDetailScreen: React.FC = () => {
         ref={flatListRef}
         data={filteredHistory}
         onScrollToIndexFailed={(info) => {
-          const wait = new Promise(resolve => setTimeout(resolve, 500));
-          wait.then(() => {
-            flatListRef.current?.scrollToIndex({ index: info.index, animated: true });
-          });
+          flatListRef.current?.scrollToOffset({ offset: info.averageItemLength * info.index, animated: false });
+          setTimeout(() => {
+            flatListRef.current?.scrollToIndex({ index: info.index, animated: false });
+          }, 100);
         }}
         renderItem={({ item, index }) => {
           const previousEntry = index < filteredHistory.length - 1 ? filteredHistory[index + 1] : undefined;


### PR DESCRIPTION
Fix flatlist scrolling delay when unrendered items are involved\n\nWhen randomly jumping to an item that hasn't been rendered yet, the flatlist was waiting 500ms and animating, which caused significant delays and lag especially when dealing with large images. This switches `animated: false` and jumps via offset to force the item to layout before re-attempting `scrollToIndex` immediately.

---
*PR created automatically by Jules for task [1077658109801804794](https://jules.google.com/task/1077658109801804794) started by @malmiski*