### PR TITLE
fix: Resolve OOM crashes in iOS Chrome during large image loading

### DIFF
--- a/ActivityTracker/src/components/ActivityHistoryItem.tsx
+++ b/ActivityTracker/src/components/ActivityHistoryItem.tsx
@@ -1,5 +1,5 @@
-import React, { useState, memo } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Image, ScrollView } from 'react-native';
+import React, { useState, useEffect, memo } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Image, ScrollView, Platform } from 'react-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import theme from '../theme/theme';
 import { Tag } from '../data/activity-details';
@@ -115,6 +115,52 @@ const ActivityHistoryItemComponent: React.FC<ActivityHistoryItemProps> = ({
   lastEntryEndDate,
   image
 }) => {
+  const [preloadedLargeImages, setPreloadedLargeImages] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    let isMounted = true;
+    const generatedUrls: string[] = [];
+
+    const loadBlobs = async () => {
+      const sourceImages = images || (image ? [image] : []);
+      if (!sourceImages || sourceImages.length === 0) return;
+
+      const loadedUrls = await Promise.all(sourceImages.map(async (imgStr) => {
+        if (imgStr === "failed") return imgStr;
+        const uri = imgStr.startsWith('data:') ? imgStr : `data:image/jpeg;base64,${imgStr}`;
+        if (uri.startsWith('data:')) {
+          try {
+            const res = await fetch(uri);
+            const blob = await res.blob();
+            const objectUrl = URL.createObjectURL(blob);
+            if (!isMounted) {
+              URL.revokeObjectURL(objectUrl);
+              return uri;
+            }
+            generatedUrls.push(objectUrl);
+            return objectUrl;
+          } catch (e) {
+            console.error("Error creating object URL in preloader", e);
+            return uri;
+          }
+        }
+        return uri;
+      }));
+
+      if (isMounted) {
+        setPreloadedLargeImages(loadedUrls);
+      }
+    };
+
+    loadBlobs();
+
+    return () => {
+      isMounted = false;
+      generatedUrls.forEach(url => URL.revokeObjectURL(url));
+    };
+  }, [images, image]);
+
   const firstLine = notes ? notes.split('\n')[0] : '';
   const duration = formatDuration(startDate, endDate);
   const isDifferentDate = startDate.getTime() !== endDate.getTime();
@@ -151,7 +197,11 @@ const ActivityHistoryItemComponent: React.FC<ActivityHistoryItemProps> = ({
 
     // Large Mode
     if (imageMode === 'large') {
-      const itemsToRender = availableImages || availableThumbnails || [];
+      let itemsToRender = availableImages || availableThumbnails || [];
+      if (Platform.OS === 'web' && preloadedLargeImages && availableImages) {
+        itemsToRender = preloadedLargeImages;
+      }
+
       if (!itemsToRender || itemsToRender.length === 0) return null;
 
       return <LargeImageGallery images={itemsToRender} />;

--- a/ActivityTracker/src/components/LargeImageGallery.tsx
+++ b/ActivityTracker/src/components/LargeImageGallery.tsx
@@ -12,7 +12,6 @@ const LargeImageGallery: React.FC<LargeImageGalleryProps> = ({ images }) => {
   const initialWidth = Platform.OS === 'web' ? screenWidth - 40 : 0;
   const [containerWidth, setContainerWidth] = useState<number>(initialWidth);
   const [imageSizes, setImageSizes] = useState<{ [key: number]: { width: number, height: number } }>({});
-  const [objectUrls, setObjectUrls] = useState<{ [key: number]: string }>({});
   const [currentIndex, setCurrentIndex] = useState(0);
   const scrollViewRef = useRef<ScrollView>(null);
 
@@ -20,29 +19,14 @@ const LargeImageGallery: React.FC<LargeImageGalleryProps> = ({ images }) => {
     if (containerWidth === 0) return;
 
     let isMounted = true;
-    const generatedUrls: string[] = [];
 
     const loadImages = async () => {
       const promises = images.map(async (imgStr, idx) => {
         if (imgStr === "failed") return;
-        let uri = imgStr.startsWith('data:') ? imgStr : `data:image/jpeg;base64,${imgStr}`;
+        let uri = (imgStr.startsWith('data:') || imgStr.startsWith('blob:')) ? imgStr : `data:image/jpeg;base64,${imgStr}`;
 
-        if (Platform.OS === 'web' && uri.startsWith('data:')) {
-          try {
-            const res = await fetch(uri);
-            const blob = await res.blob();
-            const objectUrl = URL.createObjectURL(blob);
-            if (!isMounted) {
-               URL.revokeObjectURL(objectUrl);
-               return;
-            }
-            generatedUrls.push(objectUrl);
-            setObjectUrls(prev => ({ ...prev, [idx]: objectUrl }));
-            uri = objectUrl;
-          } catch (e) {
-            console.error("Error creating object URL in LargeImageGallery", e);
-          }
-        }
+        // In LargeImageGallery, the Base64 conversion has already been handled
+        // upfront by ActivityHistoryItem, so imgStr is likely already a Blob URL if on web.
 
         Image.getSize(uri, (width, height) => {
           if (!isMounted) return;
@@ -69,7 +53,6 @@ const LargeImageGallery: React.FC<LargeImageGalleryProps> = ({ images }) => {
 
     return () => {
       isMounted = false;
-      generatedUrls.forEach(url => URL.revokeObjectURL(url));
     };
   }, [images, containerWidth]);
 
@@ -110,10 +93,7 @@ const LargeImageGallery: React.FC<LargeImageGalleryProps> = ({ images }) => {
         >
           {images.map((imgStr, idx) => {
             if (imgStr === "failed") return null;
-            let uri = imgStr.startsWith('data:') ? imgStr : `data:image/jpeg;base64,${imgStr}`;
-            if (objectUrls[idx]) {
-               uri = objectUrls[idx];
-            }
+            let uri = (imgStr.startsWith('data:') || imgStr.startsWith('blob:')) ? imgStr : `data:image/jpeg;base64,${imgStr}`;
             const size = imageSizes[idx] || { width: containerWidth, height: 200 };
 
             return (

--- a/ActivityTracker/src/components/LargeImageGallery.tsx
+++ b/ActivityTracker/src/components/LargeImageGallery.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { View, ScrollView, TouchableOpacity, StyleSheet, Platform, useWindowDimensions, Image } from 'react-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
+import { LazyImage } from './LazyImage';
 
 interface LargeImageGalleryProps {
   images: string[];
@@ -11,31 +12,65 @@ const LargeImageGallery: React.FC<LargeImageGalleryProps> = ({ images }) => {
   const initialWidth = Platform.OS === 'web' ? screenWidth - 40 : 0;
   const [containerWidth, setContainerWidth] = useState<number>(initialWidth);
   const [imageSizes, setImageSizes] = useState<{ [key: number]: { width: number, height: number } }>({});
+  const [objectUrls, setObjectUrls] = useState<{ [key: number]: string }>({});
   const [currentIndex, setCurrentIndex] = useState(0);
   const scrollViewRef = useRef<ScrollView>(null);
 
   useEffect(() => {
     if (containerWidth === 0) return;
 
-    images.forEach((imgStr, idx) => {
-      if (imgStr === "failed") return;
-      const uri = imgStr.startsWith('data:') ? imgStr : `data:image/jpeg;base64,${imgStr}`;
-      Image.getSize(uri, (width, height) => {
-        let scaledWidth = width;
-        let scaledHeight = height;
+    let isMounted = true;
+    const generatedUrls: string[] = [];
 
-        if (width > containerWidth && width > 0) {
-          const ratio = containerWidth / width;
-          scaledWidth = containerWidth;
-          scaledHeight = height * ratio;
+    const loadImages = async () => {
+      const promises = images.map(async (imgStr, idx) => {
+        if (imgStr === "failed") return;
+        let uri = imgStr.startsWith('data:') ? imgStr : `data:image/jpeg;base64,${imgStr}`;
+
+        if (Platform.OS === 'web' && uri.startsWith('data:')) {
+          try {
+            const res = await fetch(uri);
+            const blob = await res.blob();
+            const objectUrl = URL.createObjectURL(blob);
+            if (!isMounted) {
+               URL.revokeObjectURL(objectUrl);
+               return;
+            }
+            generatedUrls.push(objectUrl);
+            setObjectUrls(prev => ({ ...prev, [idx]: objectUrl }));
+            uri = objectUrl;
+          } catch (e) {
+            console.error("Error creating object URL in LargeImageGallery", e);
+          }
         }
 
-        setImageSizes((prev) => ({ ...prev, [idx]: { width: scaledWidth, height: scaledHeight } }));
-      }, () => {
-         // Fallback size if fetching fails
-         setImageSizes((prev) => ({ ...prev, [idx]: { width: containerWidth, height: 200 } }));
+        Image.getSize(uri, (width, height) => {
+          if (!isMounted) return;
+          let scaledWidth = width;
+          let scaledHeight = height;
+
+          if (width > containerWidth && width > 0) {
+            const ratio = containerWidth / width;
+            scaledWidth = containerWidth;
+            scaledHeight = height * ratio;
+          }
+
+          setImageSizes((prev) => ({ ...prev, [idx]: { width: scaledWidth, height: scaledHeight } }));
+        }, () => {
+           if (!isMounted) return;
+           setImageSizes((prev) => ({ ...prev, [idx]: { width: containerWidth, height: 200 } }));
+        });
       });
-    });
+
+      await Promise.all(promises);
+    };
+
+    loadImages();
+
+    return () => {
+      isMounted = false;
+      generatedUrls.forEach(url => URL.revokeObjectURL(url));
+    };
   }, [images, containerWidth]);
 
   const maxHeight = Object.values(imageSizes).length > 0
@@ -75,7 +110,10 @@ const LargeImageGallery: React.FC<LargeImageGalleryProps> = ({ images }) => {
         >
           {images.map((imgStr, idx) => {
             if (imgStr === "failed") return null;
-            const uri = imgStr.startsWith('data:') ? imgStr : `data:image/jpeg;base64,${imgStr}`;
+            let uri = imgStr.startsWith('data:') ? imgStr : `data:image/jpeg;base64,${imgStr}`;
+            if (objectUrls[idx]) {
+               uri = objectUrls[idx];
+            }
             const size = imageSizes[idx] || { width: containerWidth, height: 200 };
 
             return (
@@ -88,7 +126,7 @@ const LargeImageGallery: React.FC<LargeImageGalleryProps> = ({ images }) => {
                   alignItems: 'center'
                 }}
               >
-                <Image
+                <LazyImage
                   source={{ uri }}
                   style={{ width: size.width, height: size.height, borderRadius: 10 }}
                   resizeMode="contain"

--- a/ActivityTracker/src/components/LazyImage.test.tsx
+++ b/ActivityTracker/src/components/LazyImage.test.tsx
@@ -53,6 +53,6 @@ describe('LazyImage', () => {
       );
     });
     expect(tree.toJSON()).not.toBeNull();
-    expect(tree.toJSON().type).toBe('div');
+    expect(tree.toJSON().type).toBe('View');
   });
 });

--- a/ActivityTracker/src/components/LazyImage.tsx
+++ b/ActivityTracker/src/components/LazyImage.tsx
@@ -7,7 +7,41 @@ interface LazyImageProps extends ImageProps {
 
 export const LazyImage: React.FC<LazyImageProps> = ({ source, style, placeholderStyle, ...props }) => {
   const [isVisible, setIsVisible] = useState(Platform.OS !== 'web');
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
   const containerRef = useRef<any>(null);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    setObjectUrl(null);
+    if (!isVisible) return;
+
+    let isMounted = true;
+    let urlToRevoke: string | null = null;
+
+    if (typeof source === 'object' && source !== null && 'uri' in source) {
+      const uri = (source as any).uri;
+      if (typeof uri === 'string' && uri.startsWith('data:')) {
+        fetch(uri)
+          .then(res => res.blob())
+          .then(blob => {
+            if (!isMounted) return;
+            const url = URL.createObjectURL(blob);
+            urlToRevoke = url;
+            setObjectUrl(url);
+          })
+          .catch(e => {
+            console.error("Error creating object URL in LazyImage", e);
+          });
+      }
+    }
+
+    return () => {
+      isMounted = false;
+      if (urlToRevoke) {
+        URL.revokeObjectURL(urlToRevoke);
+      }
+    };
+  }, [source, isVisible]);
 
   useEffect(() => {
     if (Platform.OS !== 'web') return;
@@ -41,17 +75,44 @@ export const LazyImage: React.FC<LazyImageProps> = ({ source, style, placeholder
   }, []);
 
   if (isVisible) {
-    return <Image source={source} style={style} {...props} />;
+    let finalSource = source;
+    let isBase64 = false;
+
+    if (typeof source === 'object' && source !== null && 'uri' in source) {
+      const uri = (source as any).uri;
+      if (typeof uri === 'string' && uri.startsWith('data:')) {
+        isBase64 = true;
+      }
+    }
+
+    if (Platform.OS === 'web' && isBase64 && !objectUrl) {
+      // Waiting for blob conversion
+      return (
+        <View
+          ref={containerRef}
+          style={[
+            style,
+            placeholderStyle,
+            { backgroundColor: 'transparent' }
+          ]}
+        />
+      );
+    }
+
+    if (objectUrl && typeof source === 'object' && source !== null && 'uri' in source) {
+      finalSource = { ...source, uri: objectUrl };
+    }
+    return <Image source={finalSource} style={style} {...props} />;
   }
 
   return (
-    <div
+    <View
       ref={containerRef}
-      style={{
-        ...StyleSheet.flatten(style),
-        ...StyleSheet.flatten(placeholderStyle),
-        backgroundColor: 'transparent',
-      }}
+      style={[
+        style,
+        placeholderStyle,
+        { backgroundColor: 'transparent' }
+      ]}
     />
   );
 };


### PR DESCRIPTION
Fixes OOM issues in iOS Chrome browser when rendering heavily base64 encoded images. Converted Base64 strings to Blob objects generating Object URLs via `fetch().then(res => res.blob())` to prevent excessive string allocations in DOM. Added `LazyImage` component using React `IntersectionObserver` to defer decoding and loading of images until active in viewport.

---
*PR created automatically by Jules for task [4453514603832520006](https://jules.google.com/task/4453514603832520006) started by @malmiski*